### PR TITLE
Added Brian's fix to escape apostrophes

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -28,6 +28,8 @@ var escape = function(query) {
         return '\\b';
       case '\t':
         return '\\t';
+      case '\'':
+        return '\'\'';
       case '\x1a':
         return '\\Z';
       default:


### PR DESCRIPTION
Escape apostrophes in the URL's query strings like ...?WhatIsGreenAndSitsInTheSunAllDay=PattyO'Furniture